### PR TITLE
check if el is null before attempting to destory it

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -1173,27 +1173,29 @@
 		destroy: function () {
 			var el = this.el;
 
-			el[expando] = null;
+			if (el){
+				el[expando] = null;
 
-			_off(el, 'mousedown', this._onTapStart);
-			_off(el, 'touchstart', this._onTapStart);
-			_off(el, 'pointerdown', this._onTapStart);
+				_off(el, 'mousedown', this._onTapStart);
+				_off(el, 'touchstart', this._onTapStart);
+				_off(el, 'pointerdown', this._onTapStart);
 
-			if (this.nativeDraggable) {
-				_off(el, 'dragover', this);
-				_off(el, 'dragenter', this);
+				if (this.nativeDraggable) {
+					_off(el, 'dragover', this);
+					_off(el, 'dragenter', this);
+				}
+
+				// Remove draggable attributes
+				Array.prototype.forEach.call(el.querySelectorAll('[draggable]'), function (el) {
+					el.removeAttribute('draggable');
+				});
+
+				touchDragOverListeners.splice(touchDragOverListeners.indexOf(this._onDragOver), 1);
+
+				this._onDrop();
+
+				this.el = el = null;
 			}
-
-			// Remove draggable attributes
-			Array.prototype.forEach.call(el.querySelectorAll('[draggable]'), function (el) {
-				el.removeAttribute('draggable');
-			});
-
-			touchDragOverListeners.splice(touchDragOverListeners.indexOf(this._onDragOver), 1);
-
-			this._onDrop();
-
-			this.el = el = null;
 		}
 	};
 


### PR DESCRIPTION
[DE39798](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F404638387292&fdp=true)

Issue:
- Edge calls destroy() twice when attempting to attach a new rubric or cancel attaching it 
- The first time destroy() is called from, el will be set to null 
- Since it is set to null, an error will be thrown the second time destroy() is called

Fix:
- Check if el is null before attempting to destroy the object

Testing:
- Tested on Edge and on Chrome that attaching a new rubric still works
